### PR TITLE
feat(slm): wire wandb project and run name into full training runs

### DIFF
--- a/RQ/SLM/unsloth/RUNBOOK.md
+++ b/RQ/SLM/unsloth/RUNBOOK.md
@@ -236,6 +236,8 @@ python -m RQ.SLM.unsloth.train --smoke --max-steps 5 --evidence-dir "$EVIDENCE_D
 
 - Requires neither `HF_HUB_TOKEN`/`WANDB_API_KEY` nor `--host-profile` (the full-run
   credential/qualification gate is skipped when `--smoke` is set).
+- Trains with `report_to="none"` — no wandb run is created and no `WANDB_API_KEY` is read, so
+  this step is safe to run on a host with no wandb credentials configured.
 - **This is the step that writes `$EVIDENCE_DIR/overflow-rows.json`** (row-1326 exclusion,
   1399 retained — see §6). Passing the same `$EVIDENCE_DIR` here pre-populates the file the
   full run will require to already exist.
@@ -271,6 +273,10 @@ Preconditions the code itself enforces before touching the GPU:
 - `qualification.json.status == "approved_16384"` and `approved_max_seq_length == 16384`,
   hash-bound to the current `config.yml` and `host_profile.yml` bytes.
 - `HF_HUB_TOKEN` and `WANDB_API_KEY` present in the shell environment (§2).
+- The wandb run for this training appears in project
+  `Untangling-Multi-Concern-Commits-with-Small-Language-Models` with run name
+  `qwen3.6-27b-semantic-concern-slm-unsloth-lora-<timestamp>` (the same UTC timestamp used for
+  the adapter and checkpoint directories).
 - Git provenance is computed twice, but only one call gates anything: at launch it's captured
   for informational purposes only (the result is discarded, `_ = _provenance("full")` — nothing
   enforces on it); the tree is re-derived and **enforced** only after training completes, right

--- a/RQ/SLM/unsloth/_types.py
+++ b/RQ/SLM/unsloth/_types.py
@@ -143,6 +143,7 @@ class SftKwargs(TypedDict):
     report_to: str
     gradient_checkpointing: bool
     use_cache: bool
+    run_name: NotRequired[str]
     max_steps: NotRequired[int]
 
 

--- a/RQ/SLM/unsloth/configs/qwen3_6_27b.yml
+++ b/RQ/SLM/unsloth/configs/qwen3_6_27b.yml
@@ -40,7 +40,7 @@ training:
   warmup_ratio: 0.1
   lr_scheduler_type: "linear"
   seed: 42
-  logging_steps: 100
+  logging_steps: 10
   save_strategy: "epoch"
   save_total_limit: 2
   eval_strategy: "no"

--- a/RQ/SLM/unsloth/runtime.py
+++ b/RQ/SLM/unsloth/runtime.py
@@ -74,7 +74,11 @@ def build_peft_kwargs(config: UnslothConfig) -> PeftKwargs:
 
 
 def build_sft_kwargs(
-    config: UnslothConfig, output_dir: Path, max_steps: int | None
+    config: UnslothConfig,
+    output_dir: Path,
+    max_steps: int | None,
+    report_to: str,
+    run_name: str | None,
 ) -> SftKwargs:
     kwargs: SftKwargs = {
         "output_dir": str(output_dir),
@@ -94,10 +98,12 @@ def build_sft_kwargs(
         "save_total_limit": config.training.save_total_limit,
         "eval_strategy": config.training.eval_strategy,
         "seed": config.training.seed,
-        "report_to": "wandb",
+        "report_to": report_to,
         "gradient_checkpointing": False,
         "use_cache": False,
     }
+    if run_name is not None:
+        kwargs["run_name"] = run_name
     if max_steps is not None:
         kwargs["max_steps"] = max_steps
     return kwargs
@@ -145,6 +151,8 @@ def create_trainer(
     train_dataset: Sequence[RenderedExample],
     config: UnslothConfig,
     output_dir: Path,
+    report_to: str,
+    run_name: str | None,
     max_steps: int | None = None,
 ) -> TrainerLike:
     """Lazily construct TRL and mask loss to the assistant response only."""
@@ -152,7 +160,9 @@ def create_trainer(
     templates = importlib.import_module("unsloth.chat_templates")
     if not isinstance(trl, TrlModule) or not isinstance(templates, TemplateModule):
         raise RuntimeDependencyError("local TRL or Unsloth template runtime is unavailable")
-    arguments = trl.SFTConfig(**build_sft_kwargs(config, output_dir, max_steps))
+    arguments = trl.SFTConfig(
+        **build_sft_kwargs(config, output_dir, max_steps, report_to, run_name)
+    )
     trainer = trl.SFTTrainer(
         model=runtime.model,
         args=arguments,

--- a/RQ/SLM/unsloth/train.py
+++ b/RQ/SLM/unsloth/train.py
@@ -139,13 +139,15 @@ def _adapter_template(root: Path) -> str:
         _adapter_fail("chat_template.jinja", f"cannot read ({error})")
 
 
-def _adapter_identity(config: UnslothConfig, evidence: ManifestEvidence) -> dict[str, JsonValue]:
+def _adapter_identity(
+    config: UnslothConfig, evidence: ManifestEvidence, report_to: str
+) -> dict[str, JsonValue]:
     excluded: list[JsonValue] = [{"index": row.index, "hash": row.row_hash, "token_length": row.token_length} for row in evidence.excluded_rows]
     effective: dict[str, JsonValue] = {
         "model": {"id": config.model.id, "revision": config.model.revision, "text_only": config.model.text_only, "dataset_id": config.model.dataset_id, "dataset_revision": config.model.dataset_revision},
         "precision": {"load_in_16bit": config.precision.load_in_16bit, "load_in_4bit": config.precision.load_in_4bit, "load_in_8bit": config.precision.load_in_8bit},
         "lora": {"rank": config.lora.rank, "alpha": config.lora.alpha, "dropout": config.lora.dropout, "bias": config.lora.bias, "target_modules": list(config.lora.target_modules), "exclude_modules": config.lora.exclude_modules, "use_gradient_checkpointing": config.lora.use_gradient_checkpointing},
-        "training": {"optim": config.training.optim, "learning_rate": config.training.learning_rate, "num_train_epochs": config.training.num_train_epochs, "per_device_train_batch_size": config.training.per_device_train_batch_size, "gradient_accumulation_steps": config.training.gradient_accumulation_steps, "warmup_ratio": config.training.warmup_ratio, "lr_scheduler_type": config.training.lr_scheduler_type, "seed": config.training.seed, "logging_steps": config.training.logging_steps, "save_strategy": config.training.save_strategy, "save_total_limit": config.training.save_total_limit, "eval_strategy": config.training.eval_strategy, "max_seq_length": config.training.max_seq_length, "packing": config.training.packing, "padding_side": config.training.padding_side},
+        "training": {"optim": config.training.optim, "learning_rate": config.training.learning_rate, "num_train_epochs": config.training.num_train_epochs, "per_device_train_batch_size": config.training.per_device_train_batch_size, "gradient_accumulation_steps": config.training.gradient_accumulation_steps, "warmup_ratio": config.training.warmup_ratio, "lr_scheduler_type": config.training.lr_scheduler_type, "seed": config.training.seed, "logging_steps": config.training.logging_steps, "report_to": report_to, "save_strategy": config.training.save_strategy, "save_total_limit": config.training.save_total_limit, "eval_strategy": config.training.eval_strategy, "max_seq_length": config.training.max_seq_length, "packing": config.training.packing, "padding_side": config.training.padding_side},
         "technical": {"attn_implementation": config.technical.attn_implementation, "device_map": config.technical.device_map}, "data": {"drop_rows_over_max_seq_length": config.data.drop_rows_over_max_seq_length},
         "masking": {"instruction_part": config.masking.instruction_part, "response_part": config.masking.response_part}, "output": {"adapter_dir_root": config.output.adapter_dir_root},
         "hub": {"adapter_repo": config.hub.adapter_repo, "merged_repo": config.hub.merged_repo, "gguf_repo": config.hub.gguf_repo}, "wandb": {"project": config.wandb.project, "experiment_name": config.wandb.experiment_name},
@@ -169,7 +171,12 @@ def _adapter_artifacts(root: Path, provenance: RunProvenance) -> tuple[Path, ...
     return tuple(sorted(paths, key=lambda path: path.relative_to(root).as_posix()))
 
 
-def build_manifest(config: UnslothConfig, provenance: RunProvenance, evidence: ManifestEvidence) -> RunManifest:
+def build_manifest(
+    config: UnslothConfig,
+    provenance: RunProvenance,
+    evidence: ManifestEvidence,
+    report_to: str,
+) -> RunManifest:
     root = evidence.adapter_dir
     if provenance.run_mode == "full" and not provenance.git_clean:
         _adapter_fail("git.clean", "full publication requires a clean Git worktree")
@@ -190,7 +197,7 @@ def build_manifest(config: UnslothConfig, provenance: RunProvenance, evidence: M
         _adapter_copy(profile, destination / "host_profile.yml", "host_profile")
         for name in FULL_ADAPTER_EVIDENCE[1:]:
             _adapter_copy(qualification / name, destination / name, f"qualification.{name}")
-    identity = _adapter_identity(config, evidence)
+    identity = _adapter_identity(config, evidence, report_to)
     _adapter_write_atomic(destination / "training_identity.json", (json.dumps(identity, sort_keys=True, separators=(",", ":")) + "\n").encode())
     captured: dict[str, JsonValue] = {"sha": provenance.git_sha, "clean": provenance.git_clean, "run_mode": provenance.run_mode}
     _adapter_write_atomic(destination / "provenance.json", (json.dumps(captured, sort_keys=True, separators=(",", ":")) + "\n").encode())
@@ -358,7 +365,14 @@ def run(arguments: RunArguments) -> None:
     timestamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
     adapter_dir = _adapter_dir(config, timestamp)
     checkpoint_dir = _checkpoint_dir(config, timestamp)
-    trainer = create_trainer(runtime, prepared.examples, config, checkpoint_dir, arguments.max_steps)
+    report_to = "none" if arguments.smoke else "wandb"
+    run_name = None if arguments.smoke else f"{config.wandb.experiment_name}-{timestamp}"
+    if not arguments.smoke:
+        os.environ["WANDB_PROJECT"] = config.wandb.project
+    trainer = create_trainer(
+        runtime, prepared.examples, config, checkpoint_dir,
+        report_to=report_to, run_name=run_name, max_steps=arguments.max_steps,
+    )
     trainer.train()
     trainer.save_model(str(adapter_dir))
     runtime.tokenizer.save_pretrained(str(adapter_dir))
@@ -371,6 +385,7 @@ def run(arguments: RunArguments) -> None:
             arguments.host_profile, None if arguments.smoke else evidence_dir,
             prepared.excluded_rows, len(prepared.examples),
         ),
+        report_to,
     ))
     verify_adapter(adapter_dir, arguments.config)
     if arguments.verify_adapter_path_file is not None:

--- a/__test__/unsloth/adapter_fixtures.py
+++ b/__test__/unsloth/adapter_fixtures.py
@@ -87,6 +87,7 @@ def write_contract(root: Path, *, tokenizer_form: TokenizerForm = "json") -> dic
             root, CONFIG_PATH, "{{ messages }}", None, None,
             (ExcludedRow(1326, EXCLUDED_HASH, 16816),), 1399,
         ),
+        report_to="none",
     )
     _ = write_manifest(root, manifest)
     return load_json(root / "run_manifest.json")

--- a/__test__/unsloth/test_adapter.py
+++ b/__test__/unsloth/test_adapter.py
@@ -146,7 +146,8 @@ def test_build_manifest_when_full_run_is_dirty_rejects(tmp_path: Path) -> None:
     # When/Then: full publication refuses dirty Git even though smoke validation permits it.
     with pytest.raises(ContractError, match="git.clean"):
         _ = build_manifest(
-            load_unsloth_config(CONFIG_PATH), RunProvenance("a" * 40, False, "full"), evidence
+            load_unsloth_config(CONFIG_PATH), RunProvenance("a" * 40, False, "full"), evidence,
+            report_to="wandb",
         )
 
 

--- a/__test__/unsloth/test_config.py
+++ b/__test__/unsloth/test_config.py
@@ -95,7 +95,7 @@ def test_load_config_when_canonical_parses_locked_training_values() -> None:
     assert training.warmup_ratio == 0.1
     assert training.lr_scheduler_type == "linear"
     assert training.seed == 42
-    assert training.logging_steps == 100
+    assert training.logging_steps == 10
     assert training.save_strategy == "epoch"
     assert training.save_total_limit == 2
     assert training.eval_strategy == "no"

--- a/__test__/unsloth/test_runtime.py
+++ b/__test__/unsloth/test_runtime.py
@@ -45,7 +45,16 @@ def test_runtime_builders_when_using_pinned_config_preserve_required_settings() 
     # When: pure constructor arguments are derived without ML imports.
     model_kwargs = build_model_load_kwargs(config, device_index=0, bf16_dtype="bf16")
     peft_kwargs = build_peft_kwargs(config)
-    sft_kwargs = build_sft_kwargs(config, output_dir=Path("adapter"), max_steps=None)
+    smoke_kwargs = build_sft_kwargs(
+        config, output_dir=Path("adapter"), max_steps=None, report_to="none", run_name=None
+    )
+    sft_kwargs = build_sft_kwargs(
+        config,
+        output_dir=Path("adapter"),
+        max_steps=None,
+        report_to="wandb",
+        run_name="qwen3.6-27b-semantic-concern-slm-unsloth-lora-20260101000000",
+    )
 
     # Then: all pinned loading, LoRA, and SFT policy is explicit.
     assert model_kwargs == {
@@ -77,6 +86,10 @@ def test_runtime_builders_when_using_pinned_config_preserve_required_settings() 
     assert sft_kwargs["packing"] is False
     assert sft_kwargs["save_strategy"] == "epoch"
     assert sft_kwargs["save_total_limit"] == 2
+    assert sft_kwargs["report_to"] == "wandb"
+    assert sft_kwargs.get("run_name") == "qwen3.6-27b-semantic-concern-slm-unsloth-lora-20260101000000"
+    assert smoke_kwargs["report_to"] == "none"
+    assert "run_name" not in smoke_kwargs
 
 
 def test_runtime_module_when_imported_has_no_heavy_module_imports() -> None:
@@ -266,6 +279,8 @@ def test_runtime_factories_when_injected_with_modules_use_response_only_markers(
         train_dataset=({"text": "row"},),
         config=config,
         output_dir=Path("out"),
+        report_to="wandb",
+        run_name="qwen3.6-27b-semantic-concern-slm-unsloth-lora-20260101000000",
     )
 
     # Then: SFTConfig owns data formatting; SFTTrainer receives only its upstream contract.
@@ -278,6 +293,10 @@ def test_runtime_factories_when_injected_with_modules_use_response_only_markers(
     assert sft_configurations[0]["max_length"] == 16384
     assert sft_configurations[0]["dataset_text_field"] == "text"
     assert sft_configurations[0]["packing"] is False
+    assert sft_configurations[0]["report_to"] == "wandb"
+    assert sft_configurations[0]["run_name"] == (
+        "qwen3.6-27b-semantic-concern-slm-unsloth-lora-20260101000000"
+    )
     assert dataset_rows == [[{"text": "row"}]]
     assert tuple(trainer_datasets[0].column_names) == ("text",)
     assert trainer_tokenizers == [tokenizer]

--- a/__test__/unsloth/test_train.py
+++ b/__test__/unsloth/test_train.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import hashlib
 import json
+import os
 import subprocess
 from collections.abc import Mapping, Sequence
 from pathlib import Path
@@ -348,13 +349,20 @@ def test_run_when_full_training_saves_adapter_binds_qualification_evidence_after
     evidence_dir = tmp_path / "qualification"
     captured: list[tuple[Path, Path | None, str]] = []
     captured_checkpoint_dirs: list[Path] = []
+    captured_report_to: list[str] = []
+    captured_run_names: list[str | None] = []
+    captured_manifest_report_to: list[str] = []
 
     def build_manifest_after_save(
-        config: UnslothConfig, provenance: RunProvenance, evidence: ManifestEvidence
+        config: UnslothConfig,
+        provenance: RunProvenance,
+        evidence: ManifestEvidence,
+        report_to: str = "wandb",
     ) -> RunManifest:
         _ = config
         assert trainer.saved is True
         captured.append((evidence.adapter_dir, evidence.qualification_dir, provenance.run_mode))
+        captured_manifest_report_to.append(report_to)
         return {
             "schema_version": 2, "run_mode": "full", "git": {"sha": "a" * 40, "clean": True},
             "identity": {}, "hashes": {"artifacts": {}, "template_sha256": "a" * 64},
@@ -383,10 +391,12 @@ def test_run_when_full_training_saves_adapter_binds_qualification_evidence_after
 
     def trainer_factory(
         runtime_value: FakeRuntime, examples: Sequence[RenderedExample], config: UnslothConfig,
-        output_dir: Path, max_steps: int | None,
+        output_dir: Path, report_to: str, run_name: str | None, max_steps: int | None,
     ) -> FakeTrainer:
         _ = runtime_value, examples, config, max_steps
         captured_checkpoint_dirs.append(output_dir)
+        captured_report_to.append(report_to)
+        captured_run_names.append(run_name)
         return trainer
 
     def write_manifest(adapter_dir: Path, manifest: RunManifest) -> Path:
@@ -417,24 +427,144 @@ def test_run_when_full_training_saves_adapter_binds_qualification_evidence_after
         "--config", str(REPO_ROOT / "RQ/SLM/unsloth/configs/qwen3_6_27b.yml"), "--host-profile", str(tmp_path / "host.yml"),
         "--evidence-dir", str(evidence_dir),
     ))
+    monkeypatch.delenv("WANDB_PROJECT", raising=False)
 
     # When: the trainer completes its adapter save in a full run.
+    # Then (finally): WANDB_PROJECT is set directly by the code under test, not via
+    # monkeypatch, so it cannot be auto-undone — pop it even if an assertion below fails,
+    # or it leaks into later tests.
+    try:
+        train_unsloth.run(arguments)
+
+        # Then: manifest capture receives the saved directory and full qualification evidence.
+        assert captured and captured[0][0].is_dir()
+        assert captured[0][1] == evidence_dir
+        assert captured[0][2] == "full"
+
+        # Then: the trainer's checkpoint output_dir is a sibling of adapter_dir, never
+        # adapter_dir itself — build_manifest()/validate_adapter() would reject checkpoint-*
+        # subdirectories found inside the adapter directory they walk.
+        adapter_dir = captured[0][0]
+        assert len(captured_checkpoint_dirs) == 1
+        checkpoint_dir = captured_checkpoint_dirs[0]
+        assert checkpoint_dir != adapter_dir
+        assert checkpoint_dir.parent == adapter_dir.parent
+        assert checkpoint_dir.name == "checkpoints"
+
+        # Then: a full run reports to wandb under a timestamped run name, targets the
+        # configured wandb project via the environment HF Trainer's WandbCallback reads, and
+        # echoes report_to into the manifest identity next to logging_steps.
+        assert captured_report_to == ["wandb"]
+        assert captured_manifest_report_to == ["wandb"]
+        assert len(captured_run_names) == 1
+        run_name = captured_run_names[0]
+        assert run_name is not None
+        assert run_name.startswith("qwen3.6-27b-semantic-concern-slm-unsloth-lora-")
+        assert os.environ["WANDB_PROJECT"] == (
+            "Untangling-Multi-Concern-Commits-with-Small-Language-Models"
+        )
+    finally:
+        os.environ.pop("WANDB_PROJECT", None)
+
+
+def test_run_when_smoke_training_reports_to_none_without_wandb_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Given: a smoke run, which must stay credential-free and never touch wandb.
+    from RQ.SLM.unsloth import train as train_unsloth
+    from RQ.SLM.unsloth._types import ManifestEvidence, RenderedExample, RunManifest, RunProvenance, TokenizerLike
+    from RQ.SLM.unsloth.config import UnslothConfig
+    from RQ.SLM.unsloth.data import DatasetRow
+
+    class FakeTokenizer:
+        chat_template: str = "{{ messages }}"
+
+        def save_pretrained(self, save_directory: str) -> None:
+            _ = save_directory
+
+    class FakeRuntime:
+        tokenizer: FakeTokenizer
+
+        def __init__(self) -> None:
+            self.tokenizer = FakeTokenizer()
+
+    class FakeTrainer:
+        def train(self) -> None:
+            return None
+
+        def save_model(self, output_dir: str) -> None:
+            _ = Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+    trainer = FakeTrainer()
+    captured_report_to: list[str] = []
+    captured_run_names: list[str | None] = []
+
+    def runtime(config: UnslothConfig, device_index: int) -> FakeRuntime:
+        _ = config, device_index
+        return FakeRuntime()
+
+    def split(source: Literal["local", "hub"], name: str) -> tuple[DatasetRow, ...]:
+        _ = source, name
+        return ()
+
+    def render(
+        rows: Sequence[DatasetRow], tokenizer: TokenizerLike, maximum: int
+    ) -> train_unsloth.PreparedTrainingData:
+        _ = rows, tokenizer, maximum
+        return train_unsloth.PreparedTrainingData((), ())
+
+    def trainer_factory(
+        runtime_value: FakeRuntime, examples: Sequence[RenderedExample], config: UnslothConfig,
+        output_dir: Path, report_to: str, run_name: str | None, max_steps: int | None,
+    ) -> FakeTrainer:
+        _ = runtime_value, examples, config, output_dir, max_steps
+        captured_report_to.append(report_to)
+        captured_run_names.append(run_name)
+        return trainer
+
+    def build_manifest_smoke(
+        config: UnslothConfig,
+        provenance: RunProvenance,
+        evidence: ManifestEvidence,
+        report_to: str = "wandb",
+    ) -> RunManifest:
+        _ = config, provenance, evidence, report_to
+        return {
+            "schema_version": 2, "run_mode": "smoke", "git": {"sha": "a" * 40, "clean": True},
+            "identity": {}, "hashes": {"artifacts": {}, "template_sha256": "a" * 64},
+        }
+
+    def write_manifest(adapter_dir: Path, manifest: RunManifest) -> Path:
+        _ = manifest
+        return adapter_dir / "run_manifest.json"
+
+    def verified(adapter_dir: Path, config: Path) -> None:
+        _ = adapter_dir, config
+
+    def provenance(run_mode: Literal["full", "smoke"]) -> RunProvenance:
+        return RunProvenance("a" * 40, True, run_mode)
+
+    monkeypatch.setattr(train_unsloth, "create_runtime", runtime)
+    monkeypatch.setattr(train_unsloth, "load_split", split)
+    monkeypatch.setattr(train_unsloth, "render_training_rows", render)
+    monkeypatch.setattr(train_unsloth, "create_trainer", trainer_factory)
+    monkeypatch.setattr(train_unsloth, "build_manifest", build_manifest_smoke)
+    monkeypatch.setattr(train_unsloth, "write_manifest", write_manifest)
+    monkeypatch.setattr(train_unsloth, "verify_adapter", verified)
+    monkeypatch.setattr(train_unsloth, "_provenance", provenance)
+    monkeypatch.delenv("WANDB_PROJECT", raising=False)
+    arguments = train_unsloth.parse_args((
+        "--config", str(REPO_ROOT / "RQ/SLM/unsloth/configs/qwen3_6_27b.yml"), "--smoke",
+    ))
+
+    # When: the smoke entrypoint runs without qualification evidence or credentials.
     train_unsloth.run(arguments)
 
-    # Then: manifest capture receives the saved directory and full qualification evidence.
-    assert captured and captured[0][0].is_dir()
-    assert captured[0][1] == evidence_dir
-    assert captured[0][2] == "full"
-
-    # Then: the trainer's checkpoint output_dir is a sibling of adapter_dir, never adapter_dir
-    # itself — build_manifest()/validate_adapter() would reject checkpoint-* subdirectories
-    # found inside the adapter directory they walk.
-    adapter_dir = captured[0][0]
-    assert len(captured_checkpoint_dirs) == 1
-    checkpoint_dir = captured_checkpoint_dirs[0]
-    assert checkpoint_dir != adapter_dir
-    assert checkpoint_dir.parent == adapter_dir.parent
-    assert checkpoint_dir.name == "checkpoints"
+    # Then: the smoke run never asks HF Trainer's WandbCallback to activate and never
+    # touches the wandb project environment variable.
+    assert captured_report_to == ["none"]
+    assert captured_run_names == [None]
+    assert "WANDB_PROJECT" not in os.environ
 
 
 def test_adapter_path_when_written_atomically_contains_the_validated_directory(


### PR DESCRIPTION
## Summary
- Smoke runs now pass `report_to="none"` — credential-free smoke can no longer hang or crash on the WandbCallback when `WANDB_API_KEY` is absent.
- Full runs actually reach the configured wandb project: `WANDB_PROJECT` is set from `wandb.project` before trainer construction, and the run is named `<experiment_name>-<timestamp>` with the same timestamp as the adapter/checkpoint dirs (traceability).
- `build_manifest` records `report_to` as a required, no-default param — smoke manifests truthfully say `"none"`.
- `logging_steps: 100 → 10` — the full run is only ~875 optimizer steps; 100 gave ~9 loss/grad_norm points, too sparse to track training dynamics.
- RUNBOOK §7/§8 note the wandb behaviour per mode; ACCESS POLICY and go/no-go lines untouched.

## Verification
- `uv run pytest __test__/ -q` → 285 passed
- `uv run basedpyright RQ/SLM/unsloth/` → 0 errors / 0 warnings
- Independent code review: APPROVE (finding on the manifest default resolved by making the param required)

Note: CI will show the billing-lock failure until the GitHub Actions billing issue is resolved; the suite above is the same CPU-only pytest CI runs.