### PR TITLE
chore(evidence): regenerate the combination-coverage audit for SEED=43

### DIFF
--- a/.omo/evidence/dataset/combination_coverage.md
+++ b/.omo/evidence/dataset/combination_coverage.md
@@ -19,9 +19,9 @@ Joined-token metrics re-encode `''.join(json.loads(diff))` with `cl100k_base`.
 | --- | --- |
 | 1 | 7/7 |
 | 2 | 21/21 |
-| 3 | 29/35 |
-| 4 | 33/35 |
-| 5 | 20/21 |
+| 3 | 32/35 |
+| 4 | 30/35 |
+| 5 | 21/21 |
 
 ## Missing test-split combinations: reachability and cause attribution
 
@@ -31,17 +31,16 @@ A *reachable* combo that produced no row is only a defect if the sampler had eno
 
 | Combination | repos with all types | feasible repos | witness joined tokens | binding constraint | verdict |
 | --- | --- | --- | --- | --- | --- |
-| (build, ci, test) | 4 | 4 | 676 | none: a <= 12288-token single-repo witness exists | reachable |
-| (build, feat, fix) | 9 | 9 | 741 | none: a <= 12288-token single-repo witness exists | reachable |
-| (build, feat, test) | 10 | 10 | 777 | none: a <= 12288-token single-repo witness exists | reachable |
-| (ci, docs, test) | 4 | 4 | 570 | none: a <= 12288-token single-repo witness exists | reachable |
-| (docs, fix, refactor) | 7 | 7 | 452 | none: a <= 12288-token single-repo witness exists | reachable |
-| (feat, refactor, test) | 12 | 12 | 930 | none: a <= 12288-token single-repo witness exists | reachable |
-| (build, feat, fix, refactor) | 8 | 8 | 1055 | none: a <= 12288-token single-repo witness exists | reachable |
-| (build, fix, refactor, test) | 9 | 9 | 795 | none: a <= 12288-token single-repo witness exists | reachable |
-| (build, ci, feat, fix, refactor) | 3 | 3 | 2363 | none: a <= 12288-token single-repo witness exists | reachable |
+| (build, ci, docs) | 2 | 2 | 580 | none: a <= 12288-token single-repo witness exists | reachable |
+| (build, docs, test) | 6 | 6 | 635 | none: a <= 12288-token single-repo witness exists | reachable |
+| (ci, feat, fix) | 5 | 5 | 1830 | none: a <= 12288-token single-repo witness exists | reachable |
+| (build, ci, docs, fix) | 2 | 2 | 710 | none: a <= 12288-token single-repo witness exists | reachable |
+| (build, ci, fix, test) | 4 | 4 | 806 | none: a <= 12288-token single-repo witness exists | reachable |
+| (build, feat, refactor, test) | 9 | 9 | 1091 | none: a <= 12288-token single-repo witness exists | reachable |
+| (ci, docs, fix, refactor) | 3 | 3 | 574 | none: a <= 12288-token single-repo witness exists | reachable |
+| (docs, feat, refactor, test) | 8 | 8 | 1226 | none: a <= 12288-token single-repo witness exists | reachable |
 
-**Reachability:** 9 reachable; 0 unreachable (pool artifact).
+**Reachability:** 8 reachable; 0 unreachable (pool artifact).
 
 ## Draw budget: is the gap explained without a sampler defect?
 
@@ -58,45 +57,45 @@ Under a correct sampler, each concern count draws independently, so the expected
 | train | 5 | 21 | 280 | 0.00 | 0 | 77 |
 | test | 1 | 7 | 70 | 0.00 | 0 | 18 |
 | test | 2 | 21 | 70 | 0.69 | 0 | 77 |
-| test | 3 | 35 | 70 | 4.60 | 6 | 145 |
-| test | 4 | 35 | 70 | 4.60 | 2 | 145 |
-| test | 5 | 21 | 70 | 0.69 | 1 | 77 |
+| test | 3 | 35 | 70 | 4.60 | 3 | 145 |
+| test | 4 | 35 | 70 | 4.60 | 5 | 145 |
+| test | 5 | 21 | 70 | 0.69 | 0 | 77 |
 
-**Totals:** expected 10.60 uncovered, observed 9.
+**Totals:** expected 10.60 uncovered, observed 8.
 
 **Cause verdict:** the observed gap tracks the draw-budget prediction, so it is a **draw-budget shortfall, not a sampler defect**. The test split draws only 70 times per concern count while covering C(7,3)=35 combinations needs ~145 draws in expectation; the train split's 280 draws clear that bar, which is exactly why train reaches full coverage and test does not. The generator targets marginal per-type uniformity (achieved exactly) and never promises joint C(7,k) coverage.
 
 ## Atomic-commit reuse
 
 ### Train
-Used atomics: 881; mean: 4.77; median: 3.00; max: 79.
+Used atomics: 861; mean: 4.88; median: 3.00; max: 77.
 | SHA | reuse count |
 | --- | --- |
-| 7a28982e2ab8e4570aef78285f66e763de41104e | 79 |
-| 625542c31043573c74271c28bcfdc504cc5f636b | 78 |
-| 2ac99c0a66a1adc18ee4ef660608f814823dd198 | 56 |
-| c81e6a1f4839502227f920c830a28a8b712de2d5 | 54 |
-| ca41994bcffb835ceeba816c6787a07ccffbe37d | 51 |
-| 1fb55e83b58354e8449ed0b6353e591f4c47e779 | 46 |
-| 60ac03c08f942a8dda49b9f9f7d2ce7a63535414 | 40 |
-| 6aa63c9b8d4dcdbb401743adc3c9a1020d943250 | 38 |
-| 411be831591b2ea15ca9138eaf8db81f51b5101e | 35 |
-| c5e86dbc00a13a355bffadeb2db197e2fea5640f | 35 |
+| 7a28982e2ab8e4570aef78285f66e763de41104e | 77 |
+| 625542c31043573c74271c28bcfdc504cc5f636b | 71 |
+| 2ac99c0a66a1adc18ee4ef660608f814823dd198 | 50 |
+| 1fb55e83b58354e8449ed0b6353e591f4c47e779 | 47 |
+| c81e6a1f4839502227f920c830a28a8b712de2d5 | 46 |
+| 60ac03c08f942a8dda49b9f9f7d2ce7a63535414 | 43 |
+| aacf062bc7ca807de74f56f2181c43e9c01d03cd | 43 |
+| fcdd8f57c34766f3d9d3827795142474a3489422 | 40 |
+| ca41994bcffb835ceeba816c6787a07ccffbe37d | 38 |
+| 7e04a5e829d7416e312ac342a00a11787745753b | 37 |
 
 ### Test
-Used atomics: 208; mean: 5.05; median: 2.00; max: 47.
+Used atomics: 220; mean: 4.77; median: 2.00; max: 48.
 | SHA | reuse count |
 | --- | --- |
-| 6f5b1103c0893d13b42f1f7c6504c9c339840be3 | 47 |
-| be44bbdeb52c6025e81c99528ed7b0d932c5be18 | 45 |
-| 45bbdaba1490a3216decb2c1a88b8f7041a3d505 | 39 |
-| b7e38fb62aa6e8a30d72dec063b1adccd089d0aa | 35 |
-| 0e4ede620dd9a2cdc13ab9cc6da05577b39fddb8 | 32 |
-| 3730075261bc81df68f9d10f12a2d6bbffd8493c | 32 |
-| ccd1946a375e2ac10c3c591b04a435c4bc5170c2 | 31 |
-| 625cbbca0d92b8756eac6fcacc795d90527d8975 | 30 |
-| 73211952964a79d97b434dd567e6d7d34be7feb5 | 29 |
+| 6f5b1103c0893d13b42f1f7c6504c9c339840be3 | 48 |
+| 73211952964a79d97b434dd567e6d7d34be7feb5 | 43 |
+| b7e38fb62aa6e8a30d72dec063b1adccd089d0aa | 42 |
+| be44bbdeb52c6025e81c99528ed7b0d932c5be18 | 35 |
+| be2cbd9480fcbd60c3011ca57f1d761185cf52bd | 34 |
+| 45bbdaba1490a3216decb2c1a88b8f7041a3d505 | 32 |
+| 625cbbca0d92b8756eac6fcacc795d90527d8975 | 32 |
 | 076b9f5efc109b481074a81957e24ce9f4a69f08 | 28 |
+| 0e4ede620dd9a2cdc13ab9cc6da05577b39fddb8 | 28 |
+| 3730075261bc81df68f9d10f12a2d6bbffd8493c | 25 |
 
 ## Per-type pool supply versus realized demand
 
@@ -127,17 +126,17 @@ Used atomics: 208; mean: 5.05; median: 2.00; max: 47.
 ### Train
 | statistic | tokens |
 | --- | --- |
-| P50 | 2363.00 |
-| P90 | 8031.30 |
-| P95 | 10030.40 |
-| P99 | 11726.35 |
-| max | 12269 |
+| P50 | 2249.00 |
+| P90 | 8053.10 |
+| P95 | 9931.05 |
+| P99 | 11539.76 |
+| max | 12196 |
 
 ### Test
 | statistic | tokens |
 | --- | --- |
-| P50 | 2500.50 |
-| P90 | 8854.60 |
-| P95 | 10073.00 |
-| P99 | 11733.11 |
-| max | 12221 |
+| P50 | 2558.50 |
+| P90 | 9150.50 |
+| P95 | 10135.00 |
+| P99 | 11629.47 |
+| max | 12109 |


### PR DESCRIPTION
Follow-up to #13. The tracked combination-coverage audit under `.omo/evidence/dataset/` still described the seed-42 test split. Regenerated with `datasets/scripts/audit_combination_coverage.py`; the new figures (k=3 32/35, k=4 30/35, k=5 21/21 — total 111/119) match the constants asserted in `__test__/test_dataset_distribution.py`.