### PR TITLE
fix(unsloth): unblock 27B certification and stop the result fixtures drifting

### DIFF
--- a/RQ/SLM/unsloth/_types.py
+++ b/RQ/SLM/unsloth/_types.py
@@ -35,7 +35,7 @@ class ModelLoadKwargs(TypedDict):
     text_only: bool
     trust_remote_code: bool
     attn_implementation: str
-    use_gradient_checkpointing: str
+    use_gradient_checkpointing: bool | str
     device_map: dict[str, int]
 
 
@@ -46,7 +46,7 @@ class PeftKwargs(TypedDict):
     lora_alpha: int
     lora_dropout: float
     bias: str
-    use_gradient_checkpointing: str
+    use_gradient_checkpointing: bool | str
     random_state: int
     max_seq_length: int
     exclude_modules: str

--- a/RQ/SLM/unsloth/config.py
+++ b/RQ/SLM/unsloth/config.py
@@ -50,7 +50,7 @@ class LoraConfig:
     bias: str
     target_modules: tuple[str, ...]
     exclude_modules: str
-    use_gradient_checkpointing: str
+    use_gradient_checkpointing: bool | str
 
 
 @dataclass(frozen=True, slots=True)
@@ -243,6 +243,15 @@ class _Section:
     def boolean(self, key: str) -> bool:
         return _boolean(_value(self.values, key, self._field(key)), self._field(key))
 
+    def checkpointing(self, key: str) -> bool | str:
+        # Unsloth reads this field as True/False or the sentinel "unsloth" (offload activations
+        # to host RAM), so its type carries meaning that text() would erase: "true" is a truthy
+        # string, so a mistyped value would still enable checkpointing and look like it worked.
+        raw = _value(self.values, key, self._field(key))
+        if isinstance(raw, bool) or raw == "unsloth":
+            return raw
+        _fail('must be true, false, or "unsloth"', self._field(key))
+
     def strings(self, key: str) -> tuple[str, ...]:
         return _strings(_value(self.values, key, self._field(key)), self._field(key))
 
@@ -266,7 +275,7 @@ def _parse_config(root: Mapping[str, JsonValue]) -> UnslothConfig:
     return UnslothConfig(
         ModelConfig(model.text("id"), model.text("revision"), model.boolean("text_only"), model.text("dataset_id"), model.text("dataset_revision")),
         PrecisionConfig(precision.boolean("load_in_16bit"), precision.boolean("load_in_4bit"), precision.boolean("load_in_8bit")),
-        LoraConfig(lora.integer("rank"), lora.integer("alpha"), lora.number("dropout"), lora.text("bias"), lora.strings("target_modules"), lora.text("exclude_modules"), lora.text("use_gradient_checkpointing")),
+        LoraConfig(lora.integer("rank"), lora.integer("alpha"), lora.number("dropout"), lora.text("bias"), lora.strings("target_modules"), lora.text("exclude_modules"), lora.checkpointing("use_gradient_checkpointing")),
         TrainingConfig(training.text("optim"), training.number("learning_rate"), training.integer("num_train_epochs"), training.integer("per_device_train_batch_size"), training.integer("gradient_accumulation_steps"), training.number("warmup_ratio"), training.text("lr_scheduler_type"), training.integer("seed"), training.integer("logging_steps"), training.text("save_strategy"), training.integer("save_total_limit"), training.text("eval_strategy"), training.integer("max_seq_length"), training.boolean("packing"), training.text("padding_side")),
         TechnicalConfig(technical.text("attn_implementation"), technical.text("device_map")),
         DataConfig(data.boolean("drop_rows_over_max_seq_length")),

--- a/RQ/SLM/unsloth/configs/qwen3_6_27b.yml
+++ b/RQ/SLM/unsloth/configs/qwen3_6_27b.yml
@@ -29,7 +29,13 @@ lora:
     - "up_proj"
     - "down_proj"
   exclude_modules: "(?:.*\\.)?(?:mtp|visual)(?:\\..*)?"
-  use_gradient_checkpointing: "unsloth"
+  # "unsloth" offloads checkpointed activations to host RAM to save VRAM. On this host that
+  # trade runs backwards: 28 GiB of VRAM sits idle while the offload takes ~23 GiB of
+  # unreclaimable shmem out of 31 GiB of RAM, and a max-length row pushes the working set past
+  # what remains — measured at step 30 of the first §8 attempt as 95% memory stall, 52 MB/s
+  # swap-in, and 193 s/step against a 41 s/step baseline. Standard checkpointing keeps the
+  # activations on the device that has room for them.
+  use_gradient_checkpointing: true
 
 training:
   optim: "adamw_torch"

--- a/RQ/SLM/unsloth/results.py
+++ b/RQ/SLM/unsloth/results.py
@@ -167,15 +167,13 @@ def _first_json_object(raw_text: str) -> dict[str, JsonValue]:
     return decoded
 
 
-def parse_model_output(raw_text: str) -> tuple[str, ...]:
-    """Extract and strictly validate one ``{\"types\": [...]}`` object."""
-    payload = _first_json_object(raw_text)
-    keys = frozenset(payload)
-    if "types" not in keys:
-        raise ModelOutputError("missing required key 'types'")
-    if keys != frozenset(("types",)):
-        raise ModelOutputError("extra keys are not allowed")
-    values = payload["types"]
+def _validate_labels(values: JsonValue) -> tuple[str, ...]:
+    """Apply the label-set rules, independent of how the labels were transported.
+
+    A label set reaches this program in two shapes: wrapped in the model's ``{"types": ...}``
+    envelope, and bare in a CSV column. The rules are the same either way, so they live here
+    once and each transport unwraps its own shape before calling in.
+    """
     if not isinstance(values, list):
         raise ModelOutputError("types must be an array")
     labels: list[str] = []
@@ -193,6 +191,32 @@ def parse_model_output(raw_text: str) -> tuple[str, ...]:
     if len(labels) != len(frozenset(labels)):
         raise ModelOutputError("duplicate label")
     return tuple(labels)
+
+
+def parse_model_output(raw_text: str) -> tuple[str, ...]:
+    """Extract and strictly validate one ``{\"types\": [...]}`` object."""
+    payload = _first_json_object(raw_text)
+    keys = frozenset(payload)
+    if "types" not in keys:
+        raise ModelOutputError("missing required key 'types'")
+    if keys != frozenset(("types",)):
+        raise ModelOutputError("extra keys are not allowed")
+    return _validate_labels(payload["types"])
+
+
+def parse_label_column(raw_text: str) -> tuple[str, ...]:
+    """Validate one CSV label column, which stores the label array bare — no envelope.
+
+    ``as_csv_row`` writes ``predicted_types`` and ``actual_types`` through the same
+    ``json.dumps(list(...))`` call, so certification must read them the same way. Validating
+    one column as an envelope and the other as an array is what made ``finalize_run`` reject
+    every run regardless of data quality.
+    """
+    try:
+        decoded = json.loads(raw_text)
+    except json.JSONDecodeError as error:
+        raise ModelOutputError("invalid JSON array") from error
+    return _validate_labels(decoded)
 
 
 def _produced_shas(row: ProducedRow, row_index: int) -> tuple[str, ...]:
@@ -307,8 +331,8 @@ def _successful_row_count(path: Path, expected_shas: Sequence[Sequence[str]]) ->
         raise FinalizationError("rows are not in test-split order", path)
     for row in rows:
         try:
-            _ = parse_model_output(row["predicted_types"])
-            _ = parse_model_output(json.dumps({"types": json.loads(row["actual_types"])}))
+            _ = parse_label_column(row["predicted_types"])
+            _ = parse_label_column(row["actual_types"])
             inference_time = float(row["inference_time"])
         except (KeyError, TypeError, ValueError, json.JSONDecodeError, ModelOutputError) as error:
             raise FinalizationError("semantic CSV row validation failed", path) from error

--- a/__test__/test_slm_legacy_contract.py
+++ b/__test__/test_slm_legacy_contract.py
@@ -244,6 +244,36 @@ def test_legacy_commit_type_labels_are_unchanged() -> None:
     assert COMMIT_TYPES == EXPECTED_COMMIT_TYPES
 
 
+def test_unsloth_writer_encodes_the_label_columns_the_legacy_way() -> None:
+    """Pin the label columns' encoding against the frozen 14B pipeline's.
+
+    ``predicted_types`` and ``actual_types`` are the columns that carry structure, that
+    ``RQ/analysis`` parses across both models, and that the writer and the finalization gate
+    already once disagreed about. The 14B writer cannot drift — it is sha256-pinned above —
+    so pinning the live writer here leaves the pair with no way to diverge.
+
+    ``shas`` is deliberately not pinned. The two pipelines do encode it differently (the 14B
+    path hands pandas a list, which stringifies to a Python repr; this one emits JSON), but
+    nothing reads that column across pipelines: ``RQ/analysis`` never touches it, and the
+    only reader is this package's own resume path, on files this package itself wrote.
+    """
+    from RQ.SLM.unsloth.results import InferenceResult
+
+    row = InferenceResult(
+        predicted_types=("fix", "test"),
+        actual_types=("fix", "refactor"),
+        inference_time=1.25,
+        shas=("abc123", "def456"),
+        context_len=4096,
+        with_message=True,
+    ).as_csv_row()
+
+    # Byte-identical to what RQ/SLM/infer.py writes for the same observation.
+    assert row["predicted_types"] == '["fix", "test"]'
+    assert row["actual_types"] == '["fix", "refactor"]'
+    assert list(row) == EXPECTED_DEFAULT_DF_COLUMNS
+
+
 def test_legacy_protected_file_digests_still_verify() -> None:
     manifest_lines = PROTECTED_FILES_PATH.read_text(encoding="utf-8").splitlines()
 

--- a/__test__/unsloth/result_fixtures.py
+++ b/__test__/unsloth/result_fixtures.py
@@ -1,0 +1,65 @@
+"""Builders for a certifiable result tree, derived from the production writer.
+
+Every row here goes through ``InferenceResult.as_csv_row`` rather than being spelled out as
+a literal dict. Certification reads back exactly what that method wrote, so a hand-authored
+fixture lets the writer and ``finalize_run`` drift apart while both sides of the suite still
+pass. They did drift: three separate hand-written fixtures claimed ``predicted_types`` held a
+``{"types": ...}`` object while the writer emitted a bare array, so ``finalize_run`` rejected
+every real run and no test noticed. Sharing one writer-derived builder makes that class of
+disagreement unrepresentable.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+from RQ.SLM.unsloth._types import CsvResultRow
+from RQ.SLM.unsloth.results import (
+    EXPECTED_SUCCESSFUL_ROWS,
+    InferenceResult,
+    expected_result_paths,
+)
+from utils.llms.constant import DEFAULT_DF_COLUMNS
+
+
+def result_row(path: Path, index: int) -> CsvResultRow:
+    """One successful row for the cell ``path`` identifies, as the writer would emit it."""
+    return InferenceResult(
+        predicted_types=("fix",),
+        actual_types=("fix",),
+        inference_time=0.0,
+        shas=(f"sha-{index}",),
+        context_len=int(path.stem.removesuffix("_zs")),
+        with_message=path.parent.name == "msg1",
+    ).as_csv_row()
+
+
+def write_result_file(
+    path: Path, row_count: int = EXPECTED_SUCCESSFUL_ROWS, order: Sequence[int] | None = None
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    indices = range(row_count) if order is None else order
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=DEFAULT_DF_COLUMNS)
+        writer.writeheader()
+        writer.writerows(result_row(path, index) for index in indices)
+
+
+def write_run_identity(run_directory: Path) -> None:
+    """Certification recovers the run's source SHA order from here, so every run needs it."""
+    run_directory.mkdir(parents=True, exist_ok=True)
+    _ = (run_directory / "run_identity.json").write_text(
+        json.dumps({"ordered_test_shas": [[f"sha-{i}"] for i in range(EXPECTED_SUCCESSFUL_ROWS)]}),
+        encoding="utf-8",
+    )
+
+
+def write_complete_run(run_directory: Path) -> None:
+    """A tree that must certify: ten full cells, a run identity, and an empty failure log."""
+    for path in expected_result_paths(run_directory):
+        write_result_file(path)
+    write_run_identity(run_directory)
+    _ = (run_directory / "failures.jsonl").write_text("", encoding="utf-8")

--- a/__test__/unsloth/test_config.py
+++ b/__test__/unsloth/test_config.py
@@ -70,7 +70,9 @@ def test_load_config_when_canonical_parses_locked_lora_values() -> None:
     assert lora.dropout == 0.05
     assert lora.bias == "none"
     assert lora.exclude_modules == r"(?:.*\.)?(?:mtp|visual)(?:\..*)?"
-    assert lora.use_gradient_checkpointing == "unsloth"
+    # `is True`, not `== True`: the string "true" and the int 1 both compare equal, and either
+    # would mean the parser had widened past the three values Unsloth actually accepts.
+    assert lora.use_gradient_checkpointing is True
 
 
 def test_target_modules_when_canonical_are_exact_and_cover_gated_delta_net() -> None:
@@ -189,8 +191,11 @@ def test_load_host_profile_when_canonical_parses_all_observed_facts() -> None:
         (r'  exclude_modules: "(?:.*\\.)?(?:mtp|visual)(?:\\..*)?"', r'  exclude_modules: "(?:.*\\.)?visual(?:\\..*)?"', "lora.exclude_modules"),
         (r'  exclude_modules: "(?:.*\\.)?(?:mtp|visual)(?:\\..*)?"', r'  exclude_modules: "(?:.*\\.)?mtp(?:\\..*)?"', "lora.exclude_modules"),
         ("  max_seq_length: 16384", "  max_seq_length: 8192", "training.max_seq_length"),
+        # "yes" is the shape a hand-edit most plausibly takes, and it is the one that would have
+        # slipped through text(): truthy, so checkpointing would switch on under a wrong type.
+        ("  use_gradient_checkpointing: true", '  use_gradient_checkpointing: "yes"', "lora.use_gradient_checkpointing"),
     ),
-    ids=("4bit", "8bit", "16bit-disabled", "flash-attention-2", "left-padding", "packing", "8bit-optimizer", "automatic-device-map", "missing-in-proj-a", "missing-mtp-exclusion", "missing-visual-exclusion", "unapproved-sequence-length"),
+    ids=("4bit", "8bit", "16bit-disabled", "flash-attention-2", "left-padding", "packing", "8bit-optimizer", "automatic-device-map", "missing-in-proj-a", "missing-mtp-exclusion", "missing-visual-exclusion", "unapproved-sequence-length", "untyped-checkpointing"),
 )
 def test_load_config_when_forbidden_value_is_present_raises_typed_error(tmp_path: Path, old: str, new: str, expected_field: str) -> None:
     # Given: one isolated YAML variant violating a locked safety invariant.

--- a/__test__/unsloth/test_infer_transformers.py
+++ b/__test__/unsloth/test_infer_transformers.py
@@ -11,7 +11,7 @@ from typing import NoReturn
 
 import pytest
 
-from RQ.SLM.unsloth.results import expected_result_paths
+from __test__.unsloth.result_fixtures import write_complete_run
 from RQ.SLM.unsloth.data import DatasetRow
 from RQ.SLM.unsloth.infer_options import (
     EvaluationOptions,
@@ -363,25 +363,10 @@ def test_main_when_verify_only_never_loads_ml_runtime(monkeypatch: pytest.Monkey
     # Given: a complete canonical result tree and a loader that would fail if called.
     from RQ.SLM.unsloth import infer as infer_transformers
 
-    for path in expected_result_paths(tmp_path):
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with path.open("w", newline="", encoding="utf-8") as handle:
-            writer = csv.DictWriter(handle, fieldnames=DEFAULT_DF_COLUMNS)
-            writer.writeheader()
-            writer.writerows({
-                "predicted_types": '{"types":["fix"]}', "actual_types": '["fix"]',
-                "inference_time": "0.0", "shas": json.dumps([f"sha-{index}"]), "precision": "1.0",
-                "recall": "1.0", "f1": "1.0", "exact_match": "True",
-                "hamming_loss": "0.0", "context_len": path.stem.removesuffix("_zs"),
-                "with_message": str(path.parent.name == "msg1"), "concern_count": "1",
-            } for index in range(350))
-    _ = (tmp_path / "failures.jsonl").write_text("", encoding="utf-8")
-    # Certification checks row order against the split the run was started on, so the run
-    # identity is as much part of a certifiable tree as the CSVs themselves.
-    _ = (tmp_path / "run_identity.json").write_text(
-        json.dumps({"ordered_test_shas": [[f"sha-{index}"] for index in range(350)]}),
-        encoding="utf-8",
-    )
+    # The tree is built by the shared writer-derived builder: certification reads back what
+    # the production writer emits, so a fixture spelled out here would only test itself.
+    write_complete_run(tmp_path)
+
     def fail_load_backend(_: PeftLoadRequest) -> NoReturn:
         pytest.fail("ML load")
 

--- a/__test__/unsloth/test_results.py
+++ b/__test__/unsloth/test_results.py
@@ -2,7 +2,6 @@ import csv
 import json
 import subprocess
 import sys
-from collections.abc import Sequence
 from dataclasses import FrozenInstanceError
 from datetime import datetime
 from pathlib import Path
@@ -26,56 +25,17 @@ from RQ.SLM.unsloth.results import (
     format_run_timestamp,
     parse_model_output,
 )
+from __test__.unsloth.result_fixtures import (
+    write_complete_run as _write_complete_run,
+    write_result_file as _write_result_file,
+    write_run_identity as _write_run_identity,
+)
 from RQ.SLM.unsloth.generation import STRICT_RESPONSE_SCHEMA
 from utils.llms.constant import COMMIT_TYPES, DEFAULT_DF_COLUMNS
 
 
 class TangledSplitLike(Protocol):
     sha_lists: tuple[tuple[str, ...], ...]
-
-
-def _result_row(path: Path, index: int) -> dict[str, str]:
-    return {
-        "predicted_types": '{"types":["fix"]}',
-        "actual_types": '["fix"]',
-        "inference_time": "0.0",
-        "shas": json.dumps([f"sha-{index}"]),
-        "precision": "1.0",
-        "recall": "1.0",
-        "f1": "1.0",
-        "exact_match": "True",
-        "hamming_loss": "0.0",
-        "context_len": path.stem.removesuffix("_zs"),
-        "with_message": str(path.parent.name == "msg1"),
-        "concern_count": "1",
-    }
-
-
-def _write_result_file(
-    path: Path, row_count: int = EXPECTED_SUCCESSFUL_ROWS, order: Sequence[int] | None = None
-) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    indices = range(row_count) if order is None else order
-    with path.open("w", newline="", encoding="utf-8") as handle:
-        writer = csv.DictWriter(handle, fieldnames=DEFAULT_DF_COLUMNS)
-        writer.writeheader()
-        writer.writerows(_result_row(path, index) for index in indices)
-
-
-def _write_run_identity(run_directory: Path) -> None:
-    """Certification recovers the run's source SHA order from here, so every run needs it."""
-    run_directory.mkdir(parents=True, exist_ok=True)
-    _ = (run_directory / "run_identity.json").write_text(
-        json.dumps({"ordered_test_shas": [[f"sha-{i}"] for i in range(EXPECTED_SUCCESSFUL_ROWS)]}),
-        encoding="utf-8",
-    )
-
-
-def _write_complete_run(run_directory: Path) -> None:
-    for path in expected_result_paths(run_directory):
-        _write_result_file(path)
-    _write_run_identity(run_directory)
-    _ = (run_directory / "failures.jsonl").write_text("", encoding="utf-8")
 
 
 def _write_shape_only_run(run_directory: Path) -> None:

--- a/__test__/unsloth/test_runtime.py
+++ b/__test__/unsloth/test_runtime.py
@@ -70,7 +70,7 @@ def test_runtime_builders_when_using_pinned_config_preserve_required_settings() 
         "text_only": True,
         "trust_remote_code": False,
         "attn_implementation": "sdpa",
-        "use_gradient_checkpointing": "unsloth",
+        "use_gradient_checkpointing": True,
         "device_map": {"": 0},
     }
     assert device_map_for(7) == {"": 7}


### PR DESCRIPTION
Four fixes that came out of running the Qwen3.6-27B base-vs-LoRA sweep end to end.

## Gradient checkpointing (`0a024fb`, `6c57fd1`)

Checkpointed activations were landing in host RAM, which killed the run on a 31 GB
box long before VRAM was the constraint. They now stay on the GPU that has room,
and the config knob is pinned to a boolean so a mistyped value fails loudly.

## Certification (`2496a98`)

`finalize_run` rejected **every** run regardless of data quality. `as_csv_row` writes
`predicted_types` and `actual_types` through one `json.dumps(list(...))` call, so both
hold a bare array — but certification validated `actual_types` as an array and
`predicted_types` as a `{"types": ...}` envelope, which no row has ever contained.
The base arm produced 3,500 complete rows with zero failures and still exited non-zero.

`parse_model_output` was doing two jobs: checking the model's envelope and applying the
label-set rules. Splitting them lets each transport unwrap its own shape and share one
definition of a valid label set, instead of wrapping a CSV array back into an envelope
just to reuse the validator.

## Fixture drift (`632347b`)

Three hand-authored fixtures each spelled out a result row, and all three claimed
`predicted_types` held an object while the writer emitted an array. Nothing connected
writer output to certification input, so every side passed against its own invention.
Fixtures now come from `InferenceResult.as_csv_row`, which makes that class of drift
unrepresentable.

## Verification

- 332 tests pass.
- Reverting the certification fix breaks three of the rebuilt fixtures; before this
  change it broke none.
- The split is behaviour-preserving: the pre-split implementation and the new one agree
  on all 27 probed inputs across both entry points, error messages included.
- Real published CSVs (2,100 rows across three models) validate clean.

`RQ/SLM/infer.py` is sha256-frozen and untouched. No published result is affected.