### PR TITLE
fig: rename model display labels to Qwen3.6/Qwen3.6-FT

### DIFF
--- a/RQ/analysis/plot_utils.py
+++ b/RQ/analysis/plot_utils.py
@@ -15,12 +15,12 @@ from typing import Optional
 # Human‑readable display names for model labels in figures
 # Keeps CSV/model keys intact while unifying how names appear in legends/ticks
 DISPLAY_NAME_MAP = {
-    "Qwen": "Qwen3",
-    "Qwen (FT)": "Qwen3-FT",
-    "QwenFT": "Qwen3-FT",
+    "Qwen": "Qwen3.6",
+    "Qwen (FT)": "Qwen3.6-FT",
+    "QwenFT": "Qwen3.6-FT",
     "LLM": "GPT-4.1",
-    "SLM": "Qwen3",
-    "Fine-tuned SLM": "Qwen3-FT",
+    "SLM": "Qwen3.6",
+    "Fine-tuned SLM": "Qwen3.6-FT",
 }
 
 


### PR DESCRIPTION
Renames the model display labels used by the RQ figure scripts so regenerated figures read `Qwen3.6` / `Qwen3.6-FT`.

Single edit site: `DISPLAY_NAME_MAP` in `RQ/analysis/plot_utils.py` (values only; CSV/model keys untouched).

Why: the manuscript's eight boxplots were regenerated from this change and are already merged into the Springer repo (PR #3). Without this on `main`, any future figure regeneration reverts to the old `Qwen3` labels and the paper's figures become unreproducible.